### PR TITLE
Permit Nested Slice Elements to be non-keyed

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -258,9 +258,6 @@ func encodeStruct(in reflect.Value) (ast.Node, *ast.ObjectKey, error) {
 		// if the item is an object list, we need to flatten out the items
 		if val, ok := val.(*ast.ObjectList); ok {
 			for _, obj := range val.Items {
-				if len(obj.Keys) == 0 {
-					return nil, nil, errors.New("nested struct slice elements must have a key field")
-				}
 				keys := append([]*ast.ObjectKey{itemKey}, obj.Keys...)
 				list.Add(&ast.ObjectItem{
 					Keys: keys,

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -349,8 +349,19 @@ func TestEncodeStruct(t *testing.T) {
 		},
 		{
 			ID:    "nested unkeyed struct slice",
-			Input: reflect.ValueOf(struct{ Foo []TestStruct }{[]TestStruct{{}}}),
-			Error: true,
+			Input: reflect.ValueOf(NestedStruct{Foo: []TestStruct{{Bar: "baz"}}}),
+			Expected: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+				&ast.ObjectItem{
+					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Foo"}}},
+					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+						&ast.ObjectItem{
+							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
+							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"baz"`}},
+						},
+					}}},
+				},
+			}}},
+			Error: false,
 		},
 	}
 
@@ -595,6 +606,10 @@ type TestInterface interface {
 
 type TestStruct struct {
 	Bar string
+}
+
+type NestedStruct struct {
+	Foo []TestStruct
 }
 
 func (TestStruct) Foo() {}

--- a/script/test
+++ b/script/test
@@ -8,7 +8,7 @@ echo "go lint..."
 test -z "$(golint ./... | tee /dev/stderr)"
 
 echo "go vet..."
-test -z "$(go tool vet -test . 2>&1 | tee /dev/stderr)"
+test -z "$(go tool vet -all -shadow . 2>&1 | tee /dev/stderr)"
 
 echo "go test..."
 go test -race -cover ./...


### PR DESCRIPTION
* Fix `script/test` to remove undocumented and deprecated `-test` flag.
* Allow nested slice elements to not have a key field, useful for building non-keyed definitions

Was having trouble converting the following:
```
type Foo struct {
	Bar []Bar
}

type Bar struct {
	Baz string
}

in := Foo{Bar: []Bar{{Baz: "something"}}}
```

To:
```
Foo {
  Baz = "something"
}
```

Which is useful when building Terraform Datadog definitions: https://www.terraform.io/docs/providers/datadog/r/timeboard.html
